### PR TITLE
Change API

### DIFF
--- a/include/api.h
+++ b/include/api.h
@@ -31,10 +31,24 @@ extern "C" {
 
 #define	SPACEMESH_API_THROTTLED_MODE	0x00008000
 
-#define SPACEMESH_API_USE_LOCKED_DEVICE	0x00001000
+// Compute API class
+typedef enum _ComputeApiClass {
+	COMPUTE_API_CLASS_UNSPECIFIED = 0,
+	COMPUTE_API_CLASS_CPU = 1, // useful for testing on systems without a cuda or vulkan GPU
+	COMPUTE_API_CLASS_CUDA = 2,
+	COMPUTE_API_CLASS_VULKAN = 3
+} ComputeApiClass;
+
+typedef struct _PostComputeProvider {
+	uint32_t id; // 0, 1, 2...
+	char model[256]; // e.g. Nvidia GTX 2700
+	ComputeApiClass compute_api; // A provided compute api
+	uint64_t performance; // Estimated performance in hashes per second
+} PostComputeProvider;
 
 SPACEMESHAPI int scryptPositions(
-    const uint8_t *id,			// 32 bytes
+	uint32_t provider_id,		// POST compute provider ID
+	const uint8_t *id,			// 32 bytes
     uint64_t start_position,	// e.g. 0 
     uint64_t end_position,		// e.g. 49,999
     uint8_t hash_len_bits,		// (1...8) for each hash output, the number of prefix bits (not bytes) to copy into the buffer
@@ -46,28 +60,15 @@ SPACEMESHAPI int scryptPositions(
     uint32_t P					// scrypt p
 );
 
-// return to the client the system GPU capabilities. E.g. OPENCL, CUDA/NVIDIA or NONE
-SPACEMESHAPI int stats();
-
 // stop all GPU work and don’t fill the passed-in buffer with any more results.
 SPACEMESHAPI int stop(
 	uint32_t ms_timeout			// timeout in milliseconds
 );
 
-// return count of GPUs
-SPACEMESHAPI int spacemesh_api_get_gpu_count(
-	int type,					// GPU type SPACEMESH_API_CUDA or SPACEMESH_API_OPENCL
-	int only_available			// return count of available GPUs only
-);
-
-// lock GPU for persistent exclusive use. returned cookie used as options in scryptPositions call
-SPACEMESHAPI int spacemesh_api_lock_gpu(
-	int type					// GPU type SPACEMESH_API_CUDA or SPACEMESH_API_OPENCL
-);
-
-// unlock GPU, locked by previous spacemesh_api_lock_gpu call
-SPACEMESHAPI void spacemesh_api_unlock_gpu(
-	int cookie					// cookie, returned by previous spacemesh_api_lock_gpu call
+// return POST compute providers info
+SPACEMESHAPI int spacemesh_api_get_providers(
+	PostComputeProvider *providers, // out providers info buffer, if NULL - return count of available providers
+	int max_providers			    // buffer size
 );
 
 #ifdef __cplusplus
@@ -76,3 +77,18 @@ SPACEMESHAPI void spacemesh_api_unlock_gpu(
 
 #endif	// #ifndef __SPACEMESH_API_H__
 
+#if 0
+	SPACEMESHAPI int scryptPositions(
+		uint32_t provider_id,		// POST compute provider ID
+		const uint8_t *id,			// 32 bytes
+		uint64_t start_position,	// e.g. 0 
+		uint64_t end_position,		// e.g. 49,999
+		uint8_t hash_len_bits,		// (1...8) for each hash output, the number of prefix bits (not bytes) to copy into the buffer
+		const uint8_t *salt,		// 32 bytes
+		uint32_t options,			// throttle etc.
+		uint8_t *out,				// memory buffer large enough to include hash_len_bits * number of requested hashes
+		uint32_t N,					// scrypt N
+		uint32_t R,					// scrypt r
+		uint32_t P					// scrypt p
+	);
+#endif

--- a/include/api.h
+++ b/include/api.h
@@ -36,7 +36,6 @@ typedef struct _PostComputeProvider {
 	uint32_t id; // 0, 1, 2...
 	char model[256]; // e.g. Nvidia GTX 2700
 	ComputeApiClass compute_api; // A provided compute api
-	uint64_t performance; // Estimated performance in hashes per second
 } PostComputeProvider;
 
 SPACEMESHAPI int scryptPositions(

--- a/include/api.h
+++ b/include/api.h
@@ -22,6 +22,8 @@ extern "C" {
 #define	SPACEMESH_API_ERROR_TIMEOUT		-2
 #define	SPACEMESH_API_ERROR_ALREADY		-3
 
+#define	SPACEMESH_API_THROTTLED_MODE	0x00008000
+
 // Compute API class
 typedef enum _ComputeApiClass {
 	COMPUTE_API_CLASS_UNSPECIFIED = 0,
@@ -34,6 +36,7 @@ typedef struct _PostComputeProvider {
 	uint32_t id; // 0, 1, 2...
 	char model[256]; // e.g. Nvidia GTX 2700
 	ComputeApiClass compute_api; // A provided compute api
+	uint64_t performance; // Estimated performance in hashes per second
 } PostComputeProvider;
 
 SPACEMESHAPI int scryptPositions(
@@ -43,6 +46,7 @@ SPACEMESHAPI int scryptPositions(
     uint64_t end_position,		// e.g. 49,999
     uint8_t hash_len_bits,		// (1...8) for each hash output, the number of prefix bits (not bytes) to copy into the buffer
     const uint8_t *salt,		// 32 bytes
+    uint32_t options,			// throttle etc.
     uint8_t *out,				// memory buffer large enough to include hash_len_bits * number of requested hashes
     uint32_t N,					// scrypt N
     uint32_t R,					// scrypt r

--- a/include/api.h
+++ b/include/api.h
@@ -22,15 +22,6 @@ extern "C" {
 #define	SPACEMESH_API_ERROR_TIMEOUT		-2
 #define	SPACEMESH_API_ERROR_ALREADY		-3
 
-#define	SPACEMESH_API_CPU				0x00000001
-#define	SPACEMESH_API_CUDA				0x00000002
-#define	SPACEMESH_API_OPENCL			0x00000004
-#define	SPACEMESH_API_VULKAN			0x00000008
-#define	SPACEMESH_API_GPU				(SPACEMESH_API_CUDA | SPACEMESH_API_OPENCL | SPACEMESH_API_VULKAN)
-#define	SPACEMESH_API_ALL				(SPACEMESH_API_CPU | SPACEMESH_API_GPU)
-
-#define	SPACEMESH_API_THROTTLED_MODE	0x00008000
-
 // Compute API class
 typedef enum _ComputeApiClass {
 	COMPUTE_API_CLASS_UNSPECIFIED = 0,
@@ -43,7 +34,6 @@ typedef struct _PostComputeProvider {
 	uint32_t id; // 0, 1, 2...
 	char model[256]; // e.g. Nvidia GTX 2700
 	ComputeApiClass compute_api; // A provided compute api
-	uint64_t performance; // Estimated performance in hashes per second
 } PostComputeProvider;
 
 SPACEMESHAPI int scryptPositions(
@@ -53,7 +43,6 @@ SPACEMESHAPI int scryptPositions(
     uint64_t end_position,		// e.g. 49,999
     uint8_t hash_len_bits,		// (1...8) for each hash output, the number of prefix bits (not bytes) to copy into the buffer
     const uint8_t *salt,		// 32 bytes
-    uint32_t options,			// throttle etc.
     uint8_t *out,				// memory buffer large enough to include hash_len_bits * number of requested hashes
     uint32_t N,					// scrypt N
     uint32_t R,					// scrypt r

--- a/src/api.c
+++ b/src/api.c
@@ -11,7 +11,6 @@ int scryptPositions(
     uint64_t end_position, // e.g. 49,999
     uint8_t hash_len_bits, // (1...8) for each hash output, the number of prefix bits (not bytes) to copy into the buffer
     const uint8_t *salt,  // 32 bytes
-    uint32_t options,  // throttle etc.
     uint8_t *out, // memory buffer large enough to include hash_len_bits * number of requested hashes
     uint32_t N,
     uint32_t R,
@@ -41,19 +40,13 @@ int scryptPositions(
 #ifdef _DEBUG
 	memset(out, 0, (end_position - start_position + 1));
 #endif
-	cgpu->drv->scrypt_positions(cgpu, (uint8_t*)data, start_position, end_position, hash_len_bits, options, out, N, R, P, &tv_start, &tv_end);
+	cgpu->drv->scrypt_positions(cgpu, (uint8_t*)data, start_position, end_position, hash_len_bits, out, N, R, P, &tv_start, &tv_end);
 
 	t = 1e-6 * (tv_end.tv_usec - tv_start.tv_usec) + (tv_end.tv_sec - tv_start.tv_sec);
 	printf("--------------------------------\n");
 	printf("Performance: %.0f (%u positions in %.2fs)\n", (end_position - start_position + 1) / t, (unsigned)(end_position - start_position + 1), t);
 	printf("--------------------------------\n");
 
-	return 0;
-}
-
-int scryptMany()
-{
-	spacemesh_api_init();
 	return 0;
 }
 

--- a/src/api.c
+++ b/src/api.c
@@ -11,6 +11,7 @@ int scryptPositions(
     uint64_t end_position, // e.g. 49,999
     uint8_t hash_len_bits, // (1...8) for each hash output, the number of prefix bits (not bytes) to copy into the buffer
     const uint8_t *salt,  // 32 bytes
+    uint32_t options,  // throttle etc.
     uint8_t *out, // memory buffer large enough to include hash_len_bits * number of requested hashes
     uint32_t N,
     uint32_t R,
@@ -40,7 +41,7 @@ int scryptPositions(
 #ifdef _DEBUG
 	memset(out, 0, (end_position - start_position + 1));
 #endif
-	cgpu->drv->scrypt_positions(cgpu, (uint8_t*)data, start_position, end_position, hash_len_bits, out, N, R, P, &tv_start, &tv_end);
+	cgpu->drv->scrypt_positions(cgpu, (uint8_t*)data, start_position, end_position, hash_len_bits, options, out, N, R, P, &tv_start, &tv_end);
 
 	t = 1e-6 * (tv_end.tv_usec - tv_start.tv_usec) + (tv_end.tv_sec - tv_start.tv_sec);
 	printf("--------------------------------\n");

--- a/src/api_internal.cpp
+++ b/src/api_internal.cpp
@@ -166,7 +166,6 @@ extern "C" int spacemesh_api_get_providers(
 			providers->id = i;
 			memcpy(providers->model, s_gpus[i].name, min(sizeof(providers->model), sizeof(s_gpus[i].name)));
 			providers->model[sizeof(providers->model) - 1] = 0;
-			providers->performance = 0;
 
 			providers++;
 			current_providers++;
@@ -176,7 +175,6 @@ extern "C" int spacemesh_api_get_providers(
 	if (s_cpu.available && current_providers < max_providers) {
 		providers->compute_api = COMPUTE_API_CLASS_CPU;
 		providers->id = i;
-		providers->performance = 0;
 		providers->model[0] = 'C';
 		providers->model[2] = 'P';
 		providers->model[3] = 'U';

--- a/src/api_internal.cpp
+++ b/src/api_internal.cpp
@@ -20,10 +20,8 @@ volatile bool abort_flag = false;
 bool opt_debug = false;
 #ifdef WIN32
 CRITICAL_SECTION applog_lock;
-CRITICAL_SECTION gpus_lock;
 #else
 pthread_mutex_t applog_lock;
-pthread_mutex_t gpus_lock;
 #endif
 
 static int s_total_devices = 0;
@@ -42,27 +40,26 @@ extern "C" void spacemesh_api_init()
 		api_inited = 1;
 #ifdef WIN32
 		InitializeCriticalSection(&applog_lock);
-		InitializeCriticalSection(&gpus_lock);
 #else
 		pthread_mutex_init(&applog_lock, NULL);
-		pthread_mutex_init(&gpus_lock, NULL);
 #endif
 
 		memset(s_gpus, 0, sizeof(s_gpus));
+		memset(&s_cpu, 0, sizeof(s_cpu));
 
 #ifdef HAVE_VULKAN
-		vulkan_drv.drv_detect(s_gpus, &s_total_devices);
+		have_vulkan = vulkan_drv.drv_detect(s_gpus, &s_total_devices) > 0;
 #endif
 
 #ifdef HAVE_CUDA
-		cuda_drv.drv_detect(s_gpus, &s_total_devices);
+		have_cuda = cuda_drv.drv_detect(s_gpus, &s_total_devices) > 0;
 #endif
 
 #ifdef HAVE_OPENCL
-		opencl_drv.drv_detect(s_gpus, &s_total_devices);
+		have_opencl = opencl_drv.drv_detect(s_gpus, &s_total_devices) > 0;
 #endif
 
-		if (0 == cpu_drv.drv_detect(&s_cpu, NULL)) {
+		if (cpu_drv.drv_detect(&s_cpu, NULL) > 0) {
 			s_cpu.drv->init(&s_cpu);
 			s_cpu.available = true;
 		}
@@ -80,56 +77,16 @@ extern "C" void spacemesh_api_init()
 	}
 }
 
-struct cgpu_info * spacemesh_api_get_available_gpu()
-{
-	struct cgpu_info *cgpu = NULL;
-	spacemesh_api_init();
-	pthread_mutex_lock(&gpus_lock);
-	for (int i = 0; i < s_total_devices; ++i) {
-		if (s_gpus[i].available && (0 != (s_gpus[i].drv->type & SPACEMESH_API_GPU))) {
-			cgpu = &s_gpus[i];
-			cgpu->available = false;
-			break;
-		}
-	}
-	pthread_mutex_unlock(&gpus_lock);
-	return cgpu;
-}
-
-struct cgpu_info * spacemesh_api_get_gpu(int id)
+extern "C" struct cgpu_info * spacemesh_api_get_gpu(int id)
 {
 	spacemesh_api_init();
 	if (id >= 0 && id < s_total_devices) {
 		return &s_gpus[id];
 	}
+	if (s_total_devices > 0 && id == s_total_devices) {
+		return &s_cpu;
+	}
 	return NULL;
-}
-
-struct cgpu_info * spacemesh_api_get_available_gpu_by_type(int type)
-{
-	struct cgpu_info *cgpu = NULL;
-	spacemesh_api_init();
-	pthread_mutex_lock(&gpus_lock);
-	for (int i = 0; i < s_total_devices; ++i) {
-		if (s_gpus[i].available && (type == s_gpus[i].drv->type)) {
-			cgpu = &s_gpus[i];
-			cgpu->available = false;
-			break;
-		}
-	}
-	pthread_mutex_unlock(&gpus_lock);
-	if (NULL == cgpu && (0 != (type & SPACEMESH_API_CPU))) {
-		cgpu = &s_cpu;
-	}
-	return cgpu;
-}
-
-void spacemesh_api_release_gpu(struct cgpu_info *cgpu)
-{
-	spacemesh_api_init();
-	pthread_mutex_lock(&gpus_lock);
-	cgpu->available = true;
-	pthread_mutex_unlock(&gpus_lock);
 }
 
 void _quit(int status)
@@ -139,71 +96,7 @@ void _quit(int status)
 	exit(status);
 }
 
-int spacemesh_api_stats()
-{
-	int devices = SPACEMESH_API_CPU;
-	spacemesh_api_init();
-	for (int i = 0; i < s_total_devices; ++i) {
-		devices |= s_gpus[i].drv->type;
-	}
-	return devices;
-}
-
-int spacemesh_api_get_gpu_count(int type, int only_available)
-{
-	int devices = 0;
-	spacemesh_api_init();
-	if (0 == type) {
-		type = SPACEMESH_API_GPU;
-	}
-	pthread_mutex_lock(&gpus_lock);
-	for (int i = 0; i < s_total_devices; ++i) {
-		if (0 != (type & s_gpus[i].drv->type)) {
-			if (only_available) {
-				if (s_gpus[i].available) {
-					devices++;
-				}
-			}
-			else {
-				devices++;
-			}
-		}
-	}
-	pthread_mutex_unlock(&gpus_lock);
-	return devices;
-}
-
-int spacemesh_api_lock_gpu(int type)
-{
-	int device = 0;
-	spacemesh_api_init();
-	if (0 == type) {
-		type = SPACEMESH_API_GPU;
-	}
-	pthread_mutex_lock(&gpus_lock);
-	for (int i = 0; i < s_total_devices; ++i) {
-		if (s_gpus[i].available && (0 != (type & s_gpus[i].drv->type))) {
-			s_gpus[i].available = false;
-			device = SPACEMESH_API_USE_LOCKED_DEVICE | (i << 8);
-			break;
-		}
-	}
-	pthread_mutex_unlock(&gpus_lock);
-	return device;
-}
-
-void spacemesh_api_unlock_gpu(int cookie)
-{
-	spacemesh_api_init();
-	pthread_mutex_lock(&gpus_lock);
-	int id = (cookie >> 8) & 0x0f;
-	if (id >= 0 && id < s_total_devices) {
-		s_gpus[id].available = true;
-	}
-	pthread_mutex_unlock(&gpus_lock);
-}
-
-int spacemesh_api_stop(uint32_t ms_timeout)
+extern "C" int spacemesh_api_stop(uint32_t ms_timeout)
 {
 	uint32_t timeout = 0;
 	if (abort_flag) {/* already called */
@@ -238,6 +131,60 @@ int spacemesh_api_stop(uint32_t ms_timeout)
 	}
 
 	return SPACEMESH_API_ERROR_NONE;
+}
+
+extern "C" int spacemesh_api_get_providers(
+	PostComputeProvider *providers, // out providers info buffer, if NULL - return count of available providers
+	int max_providers			    // buffer size
+)
+{
+	int i;
+	int current_providers = 0;
+
+	spacemesh_api_init();
+
+	if (NULL == providers) {
+		for (i = 0; i < s_total_devices; i++) {
+			if (NULL != s_gpus[i].drv && 0 != (s_gpus[i].drv->type & (SPACEMESH_API_CUDA | SPACEMESH_API_VULKAN))) {
+				current_providers++;
+			}
+		}
+		if (s_cpu.available) {
+			current_providers++;
+		}
+		return current_providers;
+	}
+
+	for (i = 0; current_providers < max_providers && i < s_total_devices; i++) {
+		if (NULL != s_gpus[i].drv && 0 != (s_gpus[i].drv->type & (SPACEMESH_API_CUDA | SPACEMESH_API_VULKAN))) {
+			if (0 != (s_gpus[i].drv->type & SPACEMESH_API_CUDA)) {
+				providers->compute_api = COMPUTE_API_CLASS_CUDA;
+			}
+			else {
+				providers->compute_api = COMPUTE_API_CLASS_VULKAN;
+			}
+			providers->id = i;
+			memcpy(providers->model, s_gpus[i].name, min(sizeof(providers->model), sizeof(s_gpus[i].name)));
+			providers->model[sizeof(providers->model) - 1] = 0;
+			providers->performance = 0;
+
+			providers++;
+			current_providers++;
+		}
+	}
+
+	if (s_cpu.available && current_providers < max_providers) {
+		providers->compute_api = COMPUTE_API_CLASS_CPU;
+		providers->id = i;
+		providers->performance = 0;
+		providers->model[0] = 'C';
+		providers->model[2] = 'P';
+		providers->model[3] = 'U';
+		providers->model[4] = 0;
+		current_providers++;
+	}
+
+	return current_providers;
 }
 
 extern bool opt_debug_diff;

--- a/src/api_internal.cpp
+++ b/src/api_internal.cpp
@@ -176,9 +176,9 @@ extern "C" int spacemesh_api_get_providers(
 		providers->compute_api = COMPUTE_API_CLASS_CPU;
 		providers->id = i;
 		providers->model[0] = 'C';
-		providers->model[2] = 'P';
-		providers->model[3] = 'U';
-		providers->model[4] = 0;
+		providers->model[1] = 'P';
+		providers->model[2] = 'U';
+		providers->model[3] = 0;
 		current_providers++;
 	}
 

--- a/src/api_internal.h
+++ b/src/api_internal.h
@@ -270,7 +270,7 @@ struct device_drv {
 
 	bool(*init)(struct cgpu_info *);
 
-	int64_t(*scrypt_positions)(struct cgpu_info *, uint8_t *pdata, uint64_t start_pos, uint64_t end_position, uint8_t hash_len_bits, uint8_t *out, uint32_t N, uint32_t r, uint32_t p, struct timeval *tv_start, struct timeval *tv_end); // (thr, pdata, start_pos, end_position, out, N, r, p, tv_start, tv_end)
+	int64_t(*scrypt_positions)(struct cgpu_info *, uint8_t *pdata, uint64_t start_pos, uint64_t end_position, uint8_t hash_len_bits, uint32_t options, uint8_t *out, uint32_t N, uint32_t r, uint32_t p, struct timeval *tv_start, struct timeval *tv_end); // (thr, pdata, start_pos, end_position, out, N, r, p, tv_start, tv_end)
 
 	void(*shutdown)(struct cgpu_info *);
 

--- a/src/api_internal.h
+++ b/src/api_internal.h
@@ -279,7 +279,7 @@ struct cgpu_info {
 	int id; // Global GPU index
 	int driver_id; // GPU index by driver
 
-	char *name;
+	char name[256];
 	void *device_data;
 	char *device_config;
 	enum dev_enable deven;

--- a/src/api_internal.h
+++ b/src/api_internal.h
@@ -48,6 +48,13 @@ typedef unsigned __int32 time_t;
 typedef char *  va_list;
 #endif
 
+#define	SPACEMESH_API_CPU				0x00000001
+#define	SPACEMESH_API_CUDA				0x00000002
+#define	SPACEMESH_API_OPENCL			0x00000004
+#define	SPACEMESH_API_VULKAN			0x00000008
+#define	SPACEMESH_API_GPU				(SPACEMESH_API_CUDA | SPACEMESH_API_OPENCL | SPACEMESH_API_VULKAN)
+#define	SPACEMESH_API_ALL				(SPACEMESH_API_CPU | SPACEMESH_API_GPU)
+
 enum {
 	LOG_ERR,
 	LOG_WARNING,
@@ -263,7 +270,7 @@ struct device_drv {
 
 	bool(*init)(struct cgpu_info *);
 
-	int64_t(*scrypt_positions)(struct cgpu_info *, uint8_t *pdata, uint64_t start_pos, uint64_t end_position, uint8_t hash_len_bits, uint32_t options, uint8_t *out, uint32_t N, uint32_t r, uint32_t p, struct timeval *tv_start, struct timeval *tv_end); // (thr, pdata, start_pos, end_position, out, N, r, p, tv_start, tv_end)
+	int64_t(*scrypt_positions)(struct cgpu_info *, uint8_t *pdata, uint64_t start_pos, uint64_t end_position, uint8_t hash_len_bits, uint8_t *out, uint32_t N, uint32_t r, uint32_t p, struct timeval *tv_start, struct timeval *tv_end); // (thr, pdata, start_pos, end_position, out, N, r, p, tv_start, tv_end)
 
 	void(*shutdown)(struct cgpu_info *);
 

--- a/src/cuda/driver-cuda.cpp
+++ b/src/cuda/driver-cuda.cpp
@@ -116,10 +116,10 @@ static bool cuda_init(struct cgpu_info *cgpu)
 					 | (((x) >> 8) & 0x0000ff00u) | (((x) >> 24) & 0x000000ffu))
 
 
-static int64_t cuda_scrypt_positions(struct cgpu_info *cgpu, uint8_t *pdata, uint64_t start_position, uint64_t end_position, uint8_t hash_len_bits, uint8_t *output, uint32_t N, uint32_t r, uint32_t p, struct timeval *tv_start, struct timeval *tv_end)
+static int64_t cuda_scrypt_positions(struct cgpu_info *cgpu, uint8_t *pdata, uint64_t start_position, uint64_t end_position, uint8_t hash_len_bits, uint32_t options, uint8_t *output, uint32_t N, uint32_t r, uint32_t p, struct timeval *tv_start, struct timeval *tv_end)
 {
 	cgpu->busy = 1;
-	if (cuda_prepare(cgpu, N, r, p, hash_len_bits, false))
+	if (cuda_prepare(cgpu, N, r, p, hash_len_bits, 0 != (options & SPACEMESH_API_THROTTLED_MODE)))
 	{
 		_cudaState *cudaState = (_cudaState *)cgpu->device_data;
 

--- a/src/cuda/driver-cuda.cpp
+++ b/src/cuda/driver-cuda.cpp
@@ -116,10 +116,10 @@ static bool cuda_init(struct cgpu_info *cgpu)
 					 | (((x) >> 8) & 0x0000ff00u) | (((x) >> 24) & 0x000000ffu))
 
 
-static int64_t cuda_scrypt_positions(struct cgpu_info *cgpu, uint8_t *pdata, uint64_t start_position, uint64_t end_position, uint8_t hash_len_bits, uint32_t options, uint8_t *output, uint32_t N, uint32_t r, uint32_t p, struct timeval *tv_start, struct timeval *tv_end)
+static int64_t cuda_scrypt_positions(struct cgpu_info *cgpu, uint8_t *pdata, uint64_t start_position, uint64_t end_position, uint8_t hash_len_bits, uint8_t *output, uint32_t N, uint32_t r, uint32_t p, struct timeval *tv_start, struct timeval *tv_end)
 {
 	cgpu->busy = 1;
-	if (cuda_prepare(cgpu, N, r, p, hash_len_bits, 0 != (options & SPACEMESH_API_THROTTLED_MODE)))
+	if (cuda_prepare(cgpu, N, r, p, hash_len_bits, false))
 	{
 		_cudaState *cudaState = (_cudaState *)cgpu->device_data;
 

--- a/src/cuda/driver-cuda.cpp
+++ b/src/cuda/driver-cuda.cpp
@@ -26,6 +26,7 @@ static void cuda_shutdown(struct cgpu_info *cgpu);
 
 static int cuda_detect(struct cgpu_info *gpus, int *active)
 {
+	int most_devices = 0;
 	int version = 0, GPU_N = 0;
 	cudaError_t err = cudaDriverGetVersion(&version);
 	if (err != cudaSuccess) {
@@ -60,23 +61,18 @@ static int cuda_detect(struct cgpu_info *gpus, int *active)
 		cgpu->pci_bus_id = props.pciBusID;
 		cgpu->pci_device_id = props.pciDeviceID;
 
-		cgpu->name = NULL;
+		memcpy(cgpu->name, props.name, min(sizeof(cgpu->name), sizeof(props.name)));
+		cgpu->name[sizeof(cgpu->name) - 1] = 0;
 		cgpu->device_config = NULL;
 		cgpu->backoff = is_windows() ? 12 : 2;
 		cgpu->lookup_gap = 1;
 		cgpu->batchsize = 1024;
-#if 0
-		if (device_name[dev_id]) {
-			free(device_name[dev_id]);
-			device_name[dev_id] = NULL;
-		}
 
-		device_name[dev_id] = strdup(props.name);
-#endif
 		*active += 1;
+		most_devices++;
 	}
 
-	return 0;
+	return most_devices;
 }
 
 static void reinit_cuda_device(struct cgpu_info *gpu)

--- a/src/opencl/driver-opencl.c
+++ b/src/opencl/driver-opencl.c
@@ -218,10 +218,10 @@ static bool opencl_init(struct cgpu_info *cgpu)
 
 #define	USE_ASYNC_BUFFER_READ	1
 
-static int64_t opencl_scrypt_positions(struct cgpu_info *cgpu, uint8_t *pdata, uint64_t start_position, uint64_t end_position, uint8_t hash_len_bits, uint8_t *output, uint32_t N, uint32_t r, uint32_t p, struct timeval *tv_start, struct timeval *tv_end)
+static int64_t opencl_scrypt_positions(struct cgpu_info *cgpu, uint8_t *pdata, uint64_t start_position, uint64_t end_position, uint8_t hash_len_bits, uint32_t options, uint8_t *output, uint32_t N, uint32_t r, uint32_t p, struct timeval *tv_start, struct timeval *tv_end)
 {
 	cgpu->busy = 1;
-	if (opencl_prepare(cgpu, N, r, p, hash_len_bits, false))
+	if (opencl_prepare(cgpu, N, r, p, hash_len_bits, 0 != (options & SPACEMESH_API_THROTTLED_MODE)))
 	{
 		_clState *clState = (_clState *)cgpu->device_data;
 		const cl_kernel *kernel = &clState->kernel[hash_len_bits];

--- a/src/opencl/driver-opencl.c
+++ b/src/opencl/driver-opencl.c
@@ -218,10 +218,10 @@ static bool opencl_init(struct cgpu_info *cgpu)
 
 #define	USE_ASYNC_BUFFER_READ	1
 
-static int64_t opencl_scrypt_positions(struct cgpu_info *cgpu, uint8_t *pdata, uint64_t start_position, uint64_t end_position, uint8_t hash_len_bits, uint32_t options, uint8_t *output, uint32_t N, uint32_t r, uint32_t p, struct timeval *tv_start, struct timeval *tv_end)
+static int64_t opencl_scrypt_positions(struct cgpu_info *cgpu, uint8_t *pdata, uint64_t start_position, uint64_t end_position, uint8_t hash_len_bits, uint8_t *output, uint32_t N, uint32_t r, uint32_t p, struct timeval *tv_start, struct timeval *tv_end)
 {
 	cgpu->busy = 1;
-	if (opencl_prepare(cgpu, N, r, p, hash_len_bits, 0 != (options & SPACEMESH_API_THROTTLED_MODE)))
+	if (opencl_prepare(cgpu, N, r, p, hash_len_bits, false))
 	{
 		_clState *clState = (_clState *)cgpu->device_data;
 		const cl_kernel *kernel = &clState->kernel[hash_len_bits];

--- a/src/opencl/ocl.c
+++ b/src/opencl/ocl.c
@@ -28,7 +28,7 @@
 #include "ICD/icd_dispatch.h"
 #include "scrypt-chacha-cl.inl"
 
-_clState *initCl(struct cgpu_info *cgpu, char *name, size_t nameSize, cl_uint hash_len_bits, bool throttled)
+_clState *initCl(struct cgpu_info *cgpu, cl_uint hash_len_bits, bool throttled)
 {
 	_clState *clState = calloc(1, sizeof(_clState));
 	bool patchbfi = false, prog_built = false;
@@ -106,14 +106,11 @@ _clState *initCl(struct cgpu_info *cgpu, char *name, size_t nameSize, cl_uint ha
 				applog(LOG_ERR, "Error %d: Getting Device Info", status);
 				return NULL;
 			}
-
 			applog(LOG_INFO, "Selected %i: %s", cgpu->driver_id, pbuff);
-			strncpy(name, pbuff, nameSize);
 		} else {
 			applog(LOG_ERR, "Invalid GPU %i", cgpu->driver_id);
 			return NULL;
 		}
-
 	}
 	else {
 		return NULL;

--- a/src/opencl/ocl.h
+++ b/src/opencl/ocl.h
@@ -43,6 +43,6 @@ typedef struct {
 	size_t compute_shaders;
 } _clState;
 
-extern _clState *initCl(struct cgpu_info *cgpu, char *name, size_t nameSize, cl_uint hash_len_bits, bool throttled);
+extern _clState *initCl(struct cgpu_info *cgpu, cl_uint hash_len_bits, bool throttled);
 
 #endif /* __OCL_H__ */

--- a/src/scrypt-jane/scrypt-jane.cpp
+++ b/src/scrypt-jane/scrypt-jane.cpp
@@ -473,7 +473,7 @@ static bool cpu_init(struct cgpu_info *cgpu)
 	return true;
 }
 
-static int64_t cpu_scrypt_positions(struct cgpu_info *cgpu, uint8_t *pdata, uint64_t start_position, uint64_t end_position, uint8_t hash_len_bits, uint8_t *output, uint32_t N, uint32_t r, uint32_t p, struct timeval *tv_start, struct timeval *tv_end)
+static int64_t cpu_scrypt_positions(struct cgpu_info *cgpu, uint8_t *pdata, uint64_t start_position, uint64_t end_position, uint8_t hash_len_bits, uint32_t options, uint8_t *output, uint32_t N, uint32_t r, uint32_t p, struct timeval *tv_start, struct timeval *tv_end)
 {
 	if (cpu_prepare(cgpu, N, r, p))
 	{

--- a/src/scrypt-jane/scrypt-jane.cpp
+++ b/src/scrypt-jane/scrypt-jane.cpp
@@ -416,7 +416,7 @@ static int cpu_detect(struct cgpu_info *cgpu, int *active)
 		*active += 1;
 	}
 
-	return 0;
+	return 1;
 }
 
 static void reinit_cpu_device(struct cgpu_info *gpu)

--- a/src/scrypt-jane/scrypt-jane.cpp
+++ b/src/scrypt-jane/scrypt-jane.cpp
@@ -473,7 +473,7 @@ static bool cpu_init(struct cgpu_info *cgpu)
 	return true;
 }
 
-static int64_t cpu_scrypt_positions(struct cgpu_info *cgpu, uint8_t *pdata, uint64_t start_position, uint64_t end_position, uint8_t hash_len_bits, uint32_t options, uint8_t *output, uint32_t N, uint32_t r, uint32_t p, struct timeval *tv_start, struct timeval *tv_end)
+static int64_t cpu_scrypt_positions(struct cgpu_info *cgpu, uint8_t *pdata, uint64_t start_position, uint64_t end_position, uint8_t hash_len_bits, uint8_t *output, uint32_t N, uint32_t r, uint32_t p, struct timeval *tv_start, struct timeval *tv_end)
 {
 	if (cpu_prepare(cgpu, N, r, p))
 	{

--- a/src/vulkan/driver-vulkan.c
+++ b/src/vulkan/driver-vulkan.c
@@ -362,10 +362,10 @@ static bool vulkan_init(struct cgpu_info *cgpu)
 	return true;
 }
 
-static int64_t vulkan_scrypt_positions(struct cgpu_info *cgpu, uint8_t *pdata, uint64_t start_position, uint64_t end_position, uint8_t hash_len_bits, uint8_t *output, uint32_t N, uint32_t r, uint32_t p, struct timeval *tv_start, struct timeval *tv_end)
+static int64_t vulkan_scrypt_positions(struct cgpu_info *cgpu, uint8_t *pdata, uint64_t start_position, uint64_t end_position, uint8_t hash_len_bits, uint32_t options, uint8_t *output, uint32_t N, uint32_t r, uint32_t p, struct timeval *tv_start, struct timeval *tv_end)
 {
 	cgpu->busy = 1;
-	if (vulkan_prepare(cgpu, N, r, p, hash_len_bits, false))
+	if (vulkan_prepare(cgpu, N, r, p, hash_len_bits, 0 != (options & SPACEMESH_API_THROTTLED_MODE)))
 	{
 		_vulkanState *state = (_vulkanState *)cgpu->device_data;
 		AlgorithmParams params;

--- a/src/vulkan/driver-vulkan.c
+++ b/src/vulkan/driver-vulkan.c
@@ -362,10 +362,10 @@ static bool vulkan_init(struct cgpu_info *cgpu)
 	return true;
 }
 
-static int64_t vulkan_scrypt_positions(struct cgpu_info *cgpu, uint8_t *pdata, uint64_t start_position, uint64_t end_position, uint8_t hash_len_bits, uint32_t options, uint8_t *output, uint32_t N, uint32_t r, uint32_t p, struct timeval *tv_start, struct timeval *tv_end)
+static int64_t vulkan_scrypt_positions(struct cgpu_info *cgpu, uint8_t *pdata, uint64_t start_position, uint64_t end_position, uint8_t hash_len_bits, uint8_t *output, uint32_t N, uint32_t r, uint32_t p, struct timeval *tv_start, struct timeval *tv_end)
 {
 	cgpu->busy = 1;
-	if (vulkan_prepare(cgpu, N, r, p, hash_len_bits, 0 != (options & SPACEMESH_API_THROTTLED_MODE)))
+	if (vulkan_prepare(cgpu, N, r, p, hash_len_bits, false))
 	{
 		_vulkanState *state = (_vulkanState *)cgpu->device_data;
 		AlgorithmParams params;

--- a/src/vulkan/driver-vulkan.c
+++ b/src/vulkan/driver-vulkan.c
@@ -244,6 +244,8 @@ static _vulkanState *initVulkan(struct cgpu_info *cgpu, char *name, size_t nameS
 
 static int vulkan_detect(struct cgpu_info *gpus, int *active)
 {
+	int most_devices = 0;
+
 	const VkApplicationInfo applicationInfo = {
 		VK_STRUCTURE_TYPE_APPLICATION_INFO,
 		0,
@@ -283,6 +285,9 @@ static int vulkan_detect(struct cgpu_info *gpus, int *active)
 			VkPhysicalDeviceProperties physicalDeviceProperties;
 			gVulkan.vkGetPhysicalDeviceProperties(gPhysicalDevices[i], &physicalDeviceProperties);
 
+			memcpy(cgpu->name, physicalDeviceProperties.deviceName, min(sizeof(cgpu->name),sizeof(physicalDeviceProperties.deviceName)));
+			cgpu->name[sizeof(cgpu->name) - 1] = 0;
+
 			VkPhysicalDeviceMemoryProperties memoryProperties;
 			gVulkan.vkGetPhysicalDeviceMemoryProperties(gPhysicalDevices[i], &memoryProperties);
 
@@ -304,8 +309,7 @@ static int vulkan_detect(struct cgpu_info *gpus, int *active)
 			}
 
 			*active += 1;
-
-			have_vulkan = true;
+			most_devices++;
 		}
 	} else {
 		applog(LOG_ERR, "No graphic cards were found by Vulkan. Use Adrenalin not Crimson and check your drivers with VulkanInfo.");
@@ -317,7 +321,7 @@ static int vulkan_detect(struct cgpu_info *gpus, int *active)
 
 	init_glslang();
 
-	return gPhysicalDeviceCount;
+	return most_devices;
 }
 
 static void reinit_vulkan_device(struct cgpu_info *gpu)

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -42,7 +42,7 @@ int main()
 			for (i = 0; i < providersCount; i++) {
 				if (providers[i].compute_api == COMPUTE_API_CLASS_CPU) {
 					memset(out + i * LABELS_COUNT, 0, LABELS_COUNT);
-					scryptPositions(providers[i].id, id, 0, LABELS_COUNT - 1, LABEL_SIZE, salt, out + i * LABELS_COUNT, 512, 1, 1);
+					scryptPositions(providers[i].id, id, 0, LABELS_COUNT - 1, LABEL_SIZE, salt, 0, out + i * LABELS_COUNT, 512, 1, 1);
 					cpu = i;
 					checkOuitput = true;
 					break;
@@ -52,7 +52,7 @@ int main()
 			for (i = 0; i < providersCount; i++) {
 				if (providers[i].compute_api != COMPUTE_API_CLASS_CPU) {
 					memset(out + i * LABELS_COUNT, 0, LABELS_COUNT);
-					scryptPositions(providers[i].id, id, 0, LABELS_COUNT - 1, LABEL_SIZE, salt, out + i * LABELS_COUNT, 512, 1, 1);
+					scryptPositions(providers[i].id, id, 0, LABELS_COUNT - 1, LABEL_SIZE, salt, 0, out + i * LABELS_COUNT, 512, 1, 1);
 					if (checkOuitput) {
 						if (0 != memcmp(out + i * LABELS_COUNT, out + cpu * LABELS_COUNT, LABELS_COUNT)) {
 							printf("WRONG result from provider %d [%s]\n", i, providers[i].model);

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -42,7 +42,7 @@ int main()
 			for (i = 0; i < providersCount; i++) {
 				if (providers[i].compute_api == COMPUTE_API_CLASS_CPU) {
 					memset(out + i * LABELS_COUNT, 0, LABELS_COUNT);
-					scryptPositions(providers[i].id, id, 0, LABELS_COUNT - 1, LABEL_SIZE, salt, 0, out + i * LABELS_COUNT, 512, 1, 1);
+					scryptPositions(providers[i].id, id, 0, LABELS_COUNT - 1, LABEL_SIZE, salt, out + i * LABELS_COUNT, 512, 1, 1);
 					cpu = i;
 					checkOuitput = true;
 					break;
@@ -52,7 +52,7 @@ int main()
 			for (i = 0; i < providersCount; i++) {
 				if (providers[i].compute_api != COMPUTE_API_CLASS_CPU) {
 					memset(out + i * LABELS_COUNT, 0, LABELS_COUNT);
-					scryptPositions(providers[i].id, id, 0, LABELS_COUNT - 1, LABEL_SIZE, salt, 0, out + i * LABELS_COUNT, 512, 1, 1);
+					scryptPositions(providers[i].id, id, 0, LABELS_COUNT - 1, LABEL_SIZE, salt, out + i * LABELS_COUNT, 512, 1, 1);
 					if (checkOuitput) {
 						if (0 != memcmp(out + i * LABELS_COUNT, out + cpu * LABELS_COUNT, LABELS_COUNT)) {
 							printf("WRONG result from provider %d [%s]\n", i, providers[i].model);


### PR DESCRIPTION
Update smesher gpu-post init #91

Replace the api-based gpu api with actual enum of available gpus and api availability.
No way to make this backward compatible. Needed to support more desirable and intuitive behavior and reflect upcoming changes in the gpu post lib api.