### PR TITLE
Return hashes per sec

### DIFF
--- a/include/api.h
+++ b/include/api.h
@@ -42,7 +42,7 @@ typedef struct _PostComputeProvider {
 SPACEMESHAPI int scryptPositions(
 	uint32_t provider_id,		// POST compute provider ID
 	const uint8_t *id,			// 32 bytes
-    uint64_t start_position,	// e.g. 0 
+    uint64_t start_position,	// e.g. 0
     uint64_t end_position,		// e.g. 49,999
     uint8_t hash_len_bits,		// (1...8) for each hash output, the number of prefix bits (not bytes) to copy into the buffer
     const uint8_t *salt,		// 32 bytes
@@ -51,10 +51,11 @@ SPACEMESHAPI int scryptPositions(
     uint32_t N,					// scrypt N
     uint32_t R,					// scrypt r
     uint32_t P,					// scrypt p
-	uint64_t *hashes_computed	// 
+	uint64_t *hashes_computed,	//
+	uint64_t *hashes_per_sec	//
 	);
 
-// stop all GPU work and don’t fill the passed-in buffer with any more results.
+// stop all GPU work and donï¿½t fill the passed-in buffer with any more results.
 SPACEMESHAPI int stop(
 	uint32_t ms_timeout			// timeout in milliseconds
 );

--- a/include/api.h
+++ b/include/api.h
@@ -55,7 +55,7 @@ SPACEMESHAPI int scryptPositions(
 	uint64_t *hashes_per_sec	//
 	);
 
-// stop all GPU work and don�t fill the passed-in buffer with any more results.
+// stop all GPU work and don't fill the passed-in buffer with any more results.
 SPACEMESHAPI int stop(
 	uint32_t ms_timeout			// timeout in milliseconds
 );

--- a/src/api.c
+++ b/src/api.c
@@ -16,7 +16,8 @@ int scryptPositions(
     uint32_t N,
     uint32_t R,
     uint32_t P,
-	uint64_t *hashes_computed
+	uint64_t *hashes_computed,
+	uint64_t *hashes_per_sec
 )
 {
 	uint32_t data[20]; // align 16
@@ -42,17 +43,28 @@ int scryptPositions(
 #ifdef _DEBUG
 	memset(out, 0, (end_position - start_position + 1));
 #endif
+
+	if (!hashes_computed) {
+		uint64_t hashes_computed_local;
+		hashes_computed = &hashes_computed_local;
+	}
+
 	cgpu->drv->scrypt_positions(cgpu, (uint8_t*)data, start_position, end_position, hash_len_bits, options, out, N, R, P, &tv_start, &tv_end, hashes_computed);
 
 	t = 1e-6 * (tv_end.tv_usec - tv_start.tv_usec) + (tv_end.tv_sec - tv_start.tv_sec);
+
 	printf("--------------------------------\n");
-	printf("Performance: %.0f (%u positions in %.2fs)\n", (end_position - start_position + 1) / t, (unsigned)(end_position - start_position + 1), t);
+	printf("Performance: %.0f (%u positions in %.2fs)\n", *hashes_computed / t, (unsigned)*hashes_computed, t);
 	printf("--------------------------------\n");
+
+	if (hashes_per_sec) {
+		*hashes_per_sec = *hashes_computed / t;
+	}
 
 	return 0;
 }
 
-// stop all GPU work and don’t fill the passed-in buffer with any more results.
+// stop all GPU work and donï¿½t fill the passed-in buffer with any more results.
 int stop(uint32_t ms_timeout)
 {
 	return spacemesh_api_stop(ms_timeout);

--- a/src/api.c
+++ b/src/api.c
@@ -7,7 +7,7 @@ extern void spacemesh_api_init();
 int scryptPositions(
 	uint32_t provider_id, // POST compute provider ID
 	const uint8_t *id, // 32 bytes
-    uint64_t start_position,  // e.g. 0 
+    uint64_t start_position,  // e.g. 0
     uint64_t end_position, // e.g. 49,999
     uint8_t hash_len_bits, // (1...8) for each hash output, the number of prefix bits (not bytes) to copy into the buffer
     const uint8_t *salt,  // 32 bytes
@@ -25,6 +25,7 @@ int scryptPositions(
 	struct timeval tv_start;
 	struct timeval tv_end;
 	struct cgpu_info *cgpu = NULL;
+	uint64_t hashes_computed_local;
 
 	memcpy(data, id, 32);
 	data[8] = 0;
@@ -45,7 +46,6 @@ int scryptPositions(
 #endif
 
 	if (!hashes_computed) {
-		uint64_t hashes_computed_local;
 		hashes_computed = &hashes_computed_local;
 	}
 

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -42,7 +42,7 @@ int main()
 			for (i = 0; i < providersCount; i++) {
 				if (providers[i].compute_api == COMPUTE_API_CLASS_CPU) {
 					memset(out + i * LABELS_COUNT, 0, LABELS_COUNT);
-					scryptPositions(providers[i].id, id, 0, LABELS_COUNT - 1, LABEL_SIZE, salt, 0, out + i * LABELS_COUNT, 512, 1, 1, NULL);
+					scryptPositions(providers[i].id, id, 0, LABELS_COUNT - 1, LABEL_SIZE, salt, 0, out + i * LABELS_COUNT, 512, 1, 1, NULL, NULL);
 					cpu = i;
 					checkOuitput = true;
 					break;
@@ -52,7 +52,7 @@ int main()
 			for (i = 0; i < providersCount; i++) {
 				if (providers[i].compute_api != COMPUTE_API_CLASS_CPU) {
 					memset(out + i * LABELS_COUNT, 0, LABELS_COUNT);
-					scryptPositions(providers[i].id, id, 0, LABELS_COUNT - 1, LABEL_SIZE, salt, 0, out + i * LABELS_COUNT, 512, 1, 1, NULL);
+					scryptPositions(providers[i].id, id, 0, LABELS_COUNT - 1, LABEL_SIZE, salt, 0, out + i * LABELS_COUNT, 512, 1, 1, NULL, NULL);
 					if (checkOuitput) {
 						if (0 != memcmp(out + i * LABELS_COUNT, out + cpu * LABELS_COUNT, LABELS_COUNT)) {
 							printf("WRONG result from provider %d [%s]\n", i, providers[i].model);


### PR DESCRIPTION
Change `scryptPositions` to return `hashes_per_sec`. It's needed because it's using the internal time duration, wheres measuring the blocking time externally (from the Go client) isn't accurate.

