### PR TITLE
PostComputeProvider.id starts from 1

### DIFF
--- a/include/api.h
+++ b/include/api.h
@@ -43,7 +43,7 @@ typedef enum _ComputeApiClass {
 } ComputeApiClass;
 
 typedef struct _PostComputeProvider {
-	uint32_t id; // 0, 1, 2...
+	uint32_t id; // 1, 2...
 	char model[256]; // e.g. Nvidia GTX 2700
 	ComputeApiClass compute_api; // A provided compute api
 } PostComputeProvider;


### PR DESCRIPTION
[Here](https://github.com/spacemeshos/gpu-post/blob/develop/src/api_internal.cpp#L175) is the evidence.